### PR TITLE
Нотисы в бекенде при включенных стилях WA2

### DIFF
--- a/lib/models/tasksAttachment.model.php
+++ b/lib/models/tasksAttachment.model.php
@@ -13,7 +13,7 @@ class tasksAttachmentModel extends waModel
         $result = '';
         $symbols = '1234567890qwertyuiopasdfghjklzxcvbnm';
         for($i = 0; $i < 16; $i++) {
-            $result .= $symbols{mt_rand(0, strlen($symbols)-1)};
+            $result .= $symbols[mt_rand(0, strlen($symbols)-1)];
         }
         return $result;
     }

--- a/templates/actions/backend/Sidebar.html
+++ b/templates/actions/backend/Sidebar.html
@@ -190,7 +190,7 @@
 
                                         <div class="progressbar">
                                             <div class="progressbar-line-wrapper">
-                                                <div class="progressbar-outer"><div class="progressbar-inner" style="width: {$scope.closed_percent}%;{if $_scope_is_100_complete}background: var(--green);{elseif !empty($scope.due_date) && $scope.due_date < date('Y-m-d')}background: var(--red);{/if}"></div></div>
+                                                <div class="progressbar-outer"><div class="progressbar-inner" style="{if isset($scope.closed_percent)}width: {$scope.closed_percent}%;{/if}{if $_scope_is_100_complete}background: var(--green);{elseif !empty($scope.due_date) && $scope.due_date < date('Y-m-d')}background: var(--red);{/if}"></div></div>
                                                 <span class="hint t-closed-percent"></span>
                                             </div>
                                         </div>

--- a/templates/actions/tasks/TasksSidebarItem.html
+++ b/templates/actions/tasks/TasksSidebarItem.html
@@ -7,7 +7,7 @@
     data-task-id="{$task.id}"
     data-task-number="{$_task_number}"
     data-task-uuid="{$task.uuid}"
-    data-status-id="{$task.status.id}"
+    data-status-id="{ifset($task, 'status', 'id', null)}"
     data-assigned-contact-id="{$task.assigned_contact_id}"
     data-task-hidden="{$_task_hidden}"
 >


### PR DESCRIPTION
При первом заходе после обновления в бекенд старой установки заметил нотис в сайдбаре

    Notice: Undefined index: closed_percent

В основной области на экране Исходящие

    Deprecated: Array and string offset access syntax with curly braces is deprecated in wa-apps/tasks/lib/models/tasksAttachment.model.php on line 16

Это у меня PHP 7.4 с отображением всех ошибок E_ALL.

Третий в списке тасков, если статус удалён.

    Notice: Undefined index: id in ...file.Tasks.html.php on line 693