### PR TITLE
JS-селектор для чекбокса Показывать задачи без назначения

### DIFF
--- a/templates/actions/kanban/Kanban.html
+++ b/templates/actions/kanban/Kanban.html
@@ -131,10 +131,10 @@
         });
 
         if (list_params.indexOf('with_backlog=1') !== -1) {
-            $main_menu.find(':checkbox').prop('checked', true);
+            $main_menu.find(':checkbox[name="with_backlog"]').prop('checked', true);
         }
 
-        $main_menu.on('click', ':checkbox', function (e) {
+        $main_menu.on('click', ':checkbox[name="with_backlog"]', function (e) {
             var $this = $(this);
 
             if ($this.is(':checked')) {


### PR DESCRIPTION
Плагин releases добавляет галочку на странице Канбан рядом со встроенной галочкой "Показывать задачи без назначения". JS-селектор в шаблоне Kanban.html срабатывает на все чекбоксы в строке-заголовке и мешает работе чекбокса от плагина.

Пул-реквест меняет селектор в JS коде, чтобы не задевать галочки, добавленные плагинами.